### PR TITLE
Gpu scheduling

### DIFF
--- a/nvidia-container-cli
+++ b/nvidia-container-cli
@@ -1,6 +1,6 @@
 #!/bin/bash
 docker pull -q nvidia/cuda:11.0.3-devel-ubuntu20.04 >/dev/null
-docker run -i --privileged --gpus all \
+docker run -i --rm --privileged --gpus all \
     -v /usr/bin/nvidia-container-cli:/usr/bin/nvidia-container-cli \
     -v /usr/lib/x86_64-linux-gnu/libnvidia-container.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-container.so.1 \
     -v /usr/lib/x86_64-linux-gnu/libnvidia-container.so.1.10.0:/usr/lib/x86_64-linux-gnu/libnvidia-container.so.1.10.0 \

--- a/nvidia-smi
+++ b/nvidia-smi
@@ -1,6 +1,6 @@
 #!/bin/bash
 docker pull -q nvidia/cuda:11.0.3-devel-ubuntu20.04 >/dev/null
-docker run -i --gpus all nvidia/cuda:11.0.3-devel-ubuntu20.04 nvidia-smi "$@"
+docker run -i --rm --gpus all nvidia/cuda:11.0.3-devel-ubuntu20.04 nvidia-smi "$@"
 if [ $? -ne 0 ]; then
     echo
     echo "No GPU found"

--- a/src/js/contracts/Modicum.sol
+++ b/src/js/contracts/Modicum.sol
@@ -21,8 +21,8 @@ contract Modicum {
     }
 
     enum Architecture {
-        amd64,
-        armv7
+        cpu,
+        gpu
     }
 
     struct JobCreator {
@@ -274,7 +274,6 @@ contract Modicum {
     }
 
     function check(Architecture arch) public{
-      //Architecture arch = Architecture.amd64;
       emit Debug(5);
       emit DebugArch(arch);
       emit DebugUint(1);
@@ -542,7 +541,7 @@ contract Modicum {
       return string(abi.encodePacked("{\"template\": \"", saneTemplate, "\", \"params\": \"", saneParams, "\"}"));
     }
 
-    function _runModule(string calldata moduleName, string calldata params, address[] memory _mediators) private returns (uint256) {
+    function _runModule(string calldata moduleName, string calldata params, address[] memory _mediators, Architecture arch) private returns (uint256) {
       require(_mediators.length > 0, "No mediators provided");
       // * register job creator address
       // * auto-assign jobid
@@ -568,7 +567,7 @@ contract Modicum {
         "",
         address(0),
         0,
-        Architecture.amd64,
+        arch,
         getModuleSpec(moduleName, params)
       );
 
@@ -577,12 +576,20 @@ contract Modicum {
       return jobID;
     }
 
-    function runModule(string calldata name, string calldata params, address[] calldata _mediators) external payable returns (uint256) {
-      return _runModule(name, params, _mediators);
+    function runModule(string calldata name, string calldata params, address[] calldata _mediators, bool requireGPU) external payable returns (uint256) {
+      Architecture arch = Architecture.cpu;
+      if(requireGPU) {
+        arch = Architecture.gpu;
+      }
+      return _runModule(name, params, _mediators, arch);
     }
 
-    function runModuleWithDefaultMediators(string calldata name, string calldata params) external payable returns (uint256) {
-      return _runModule(name, params, defaultMediators);
+    function runModuleWithDefaultMediators(string calldata name, string calldata params, bool requireGPU) external payable returns (uint256) {
+      Architecture arch = Architecture.cpu;
+      if(requireGPU) {
+        arch = Architecture.gpu;
+      }
+      return _runModule(name, params, defaultMediators, arch);
     }
 
     // NOTE: this is an example - so there are lots of "require" statements missing

--- a/src/js/contracts/NaiveExamplesClient.sol
+++ b/src/js/contracts/NaiveExamplesClient.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.6;
 
 interface ModicumContract {
-  function runModuleWithDefaultMediators(string calldata name, string calldata params) external payable returns (uint256);
+  function runModuleWithDefaultMediators(string calldata name, string calldata params, bool requireGPU) external payable returns (uint256);
 }
 
 contract NaiveExamplesClient {
@@ -18,15 +18,15 @@ contract NaiveExamplesClient {
   }
 
   function runCowsay(string memory sayWhat) public payable returns (uint256) {
-    return runModule("cowsay:v0.0.1", sayWhat);
+    return runModule("cowsay:v0.0.1", sayWhat, false);
   }
 
   function runStablediffusion(string memory prompt) public payable returns (uint256) {
-    return runModule("stable_diffusion:v0.0.1", prompt);
+    return runModule("stable_diffusion:v0.0.1", prompt, true);
   }
 
-  function runModule(string memory name, string memory params) public payable returns (uint256) {
-    return remoteContractInstance.runModuleWithDefaultMediators{value: msg.value}(name, params);
+  function runModule(string memory name, string memory params, bool requireGPU) public payable returns (uint256) {
+    return remoteContractInstance.runModuleWithDefaultMediators{value: msg.value}(name, params, requireGPU);
   }
 
   function receiveJobResults(uint256 jobID, string calldata cid) public {

--- a/src/js/scripts/fund-address.js
+++ b/src/js/scripts/fund-address.js
@@ -1,0 +1,29 @@
+const {
+  getAccount,
+} = require('../accounts')
+
+async function main() {
+  if(!process.env.ADDRESS) {
+    console.error(`no ADDRESS env found`)
+    process.exit(1)
+  }
+  if(!process.env.AMOUNT) {
+    console.error(`no AMOUNT env found`)
+    process.exit(1)
+  }
+  const fromAccount = getAccount('admin')
+  const signer = new hre.ethers.Wallet(fromAccount.privateKey, hre.ethers.provider)
+
+  const tx = await signer.sendTransaction({
+    to: process.env.ADDRESS,
+    value: ethers.utils.parseEther(process.env.AMOUNT),
+  })
+  await tx.wait()
+
+  console.log(`Moved ${process.env.AMOUNT} from admin (${fromAccount.address}) to ${process.env.ADDRESS} ${tx.hash}.`)
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/python/modicum/Enums.py
+++ b/src/python/modicum/Enums.py
@@ -1,9 +1,8 @@
 from enum import Enum
 
-
 class Architecture(Enum):
-	amd64 = 0
-	armv7 = 1
+  cpu = 0
+  gpu = 1
 
 
 class ResultStatus(Enum):

--- a/src/python/modicum/JobCreator.py
+++ b/src/python/modicum/JobCreator.py
@@ -14,6 +14,7 @@ from .PlatformClient import PlatformClient
 from . import helper
 from web3 import Web3
 from .Enums import Architecture
+from .Modules import get_bacalhau_job_arch
 
 import datetime
 
@@ -407,6 +408,8 @@ class JobCreator(PlatformClient):
 
         self.jobsPending += 1
 
+        arch = get_bacalhau_job_arch(template)
+
         msg = {
           "ijoid":round(time.time()*1000),
           "cpuTime":800000,
@@ -421,7 +424,6 @@ class JobCreator(PlatformClient):
           "uri":1,
           "directory":"0xc590dd7eed9f093d88d2f3c894b769c746bc8c9b",
           "hash":66153838227408534191608590763201001504128600065912625980963590518282769258064,
-          "arch":"amd64"
         }
 
         # self.logger.info("cpuTime: %s Type: %s" %(msg["cpuTime"],type(msg["cpuTime"])))
@@ -492,7 +494,7 @@ class JobCreator(PlatformClient):
                 "arf",
                 Web3.to_checksum_address(msg['directory']),
                 Web3.to_int(msg['hash']),
-                Architecture.amd64.value,
+                arch,
                 jsonData,
             ), {
                 "from": self.account,
@@ -505,7 +507,7 @@ class JobCreator(PlatformClient):
 #  1,
 #  '0xc590dd7eed9f093d88d2f3c894b769c746bc8c9b',
 #  66153838227408534191608590763201001504128600065912625980963590518282769258064,
-#  'amd64',
+#  'cpu',
 #  '{"template": "stable-diffusion", "params": ""}')
 
 

--- a/src/python/modicum/JobCreator.py
+++ b/src/python/modicum/JobCreator.py
@@ -410,6 +410,15 @@ class JobCreator(PlatformClient):
 
         arch = get_bacalhau_job_arch(template)
 
+        # self.logger.info("🟢🟢🟢🟢 ARCH = %s %s" % (template, arch,))
+        # self.logger.info("🟢🟢🟢🟢 ARCH = %s %s" % (template, arch,))
+        # self.logger.info("🟢🟢🟢🟢 ARCH = %s %s" % (template, arch,))
+        # self.logger.info("🟢🟢🟢🟢 ARCH = %s %s" % (template, arch,))
+
+        
+
+        # time.sleep(60 * 60)
+
         msg = {
           "ijoid":round(time.time()*1000),
           "cpuTime":800000,

--- a/src/python/modicum/Modules.py
+++ b/src/python/modicum/Modules.py
@@ -23,9 +23,9 @@ def get_bacalhau_jobspec(template_name, params):
 def get_bacalhau_job_arch(template_name):
     module = modules[template_name]
     if module.requireGPU:
-        return Architecture.cpu.value
-    else:
         return Architecture.gpu.value
+    else:
+        return Architecture.cpu.value
 
 modules = {
     "stable_diffusion:v0.0.1": _stable_diffusion,

--- a/src/python/modicum/Modules.py
+++ b/src/python/modicum/Modules.py
@@ -1,4 +1,5 @@
 from web3 import Web3
+from .Enums import Architecture
 # TODO write a guide here for how people should make modules FULLY DETERMINISTIC
 # TODO: include docker image hashes below
 
@@ -18,6 +19,13 @@ def get_bacalhau_jobspec(template_name, params):
     calling `bacalhau create <file.yaml>` on the ResourceProvider
     """
     return modules[template_name](params)
+
+def get_bacalhau_job_arch(template_name):
+    module = modules[template_name]
+    if module.requireGPU:
+        return Architecture.cpu.value
+    else:
+        return Architecture.gpu.value
 
 modules = {
     "stable_diffusion:v0.0.1": _stable_diffusion,

--- a/src/python/modicum/ResourceProvider.py
+++ b/src/python/modicum/ResourceProvider.py
@@ -1,6 +1,7 @@
 import logging
 import logging.config
 import subprocess
+import shlex
 # from . import DirectoryClient
 from . import DockerWrapper
 from .PlatformClient import PlatformClient

--- a/src/python/modicum/Solver.py
+++ b/src/python/modicum/Solver.py
@@ -109,7 +109,8 @@ class Solver(PlatformClient):
         jobOfferArch = job_offer.arch
 
         # the only case we don't match is here the resource provider is CPU only and the job requires a CPU
-        if resourceProviderArch == Architecture.cpu and jobOfferArch == Architecture.gpu:
+        if resourceProviderArch == Architecture.cpu.value and jobOfferArch == Architecture.gpu.value:
+            self.logger.info("🟢🟢🟢🟢 ARCH 🟢🟢🟢🟢\n#JO: %d\n#RO: %d" %(jobOfferArch, resourceProviderArch))
             self.logger.info(f"Architecture mismatch (RP=CPU, JO=GPU)")
             return(False, False)
 
@@ -214,12 +215,14 @@ class Solver(PlatformClient):
         
         for i in self.resource_offers:
             resource_offer = self.resource_offers[i]
+            resourceProviderArch = self.resource_providers[resource_offer.resourceProvider].arch
             # append a dict to debugJobOffers
             debugResourceOffers.append({
               "offerId": resource_offer.offerId,
               "resourceProvider": resource_offer.resourceProvider,
               "deposit": resource_offer.deposit,
-              "iroid": resource_offer.iroid
+              "iroid": resource_offer.iroid,
+              "arch": resourceProviderArch,
             })
 
         for i in self.job_offers:
@@ -229,7 +232,8 @@ class Solver(PlatformClient):
               "offerId": job_offer.offerId,
               "ijoid": job_offer.ijoid,
               "jobCreator": job_offer.jobCreator,
-              "extras": job_offer.extras
+              "extras": job_offer.extras,
+              "arch": job_offer.arch,
             })
 
 

--- a/src/python/modicum/Solver.py
+++ b/src/python/modicum/Solver.py
@@ -8,10 +8,9 @@ import datetime
 from .PlatformClient import PlatformClient
 from . import PlatformStructs as Pstruct
 from . import helper
+from .Enums import Architecture
 
 POLLING_INTERVAL = 1 # seconds
-
-
 
 class Solver(PlatformClient):
     def __init__(self,index):
@@ -106,11 +105,13 @@ class Solver(PlatformClient):
             self.logger.info("Not Enough Time to complete: %s > %s" %(completionDeadline,job_offer.completionDeadline))
             return(False, False)
 
-        #JO.arch = RP.arch
-        if self.resource_providers[resource_offer.resourceProvider].arch != job_offer.arch:
-            self.logger.info(f"Architecture mismatch (RP={self.resource_providers[resource_offer.resourceProvider].arch}, JO={job_offer.arch})")
-            return(False, False)
+        resourceProviderArch = self.resource_providers[resource_offer.resourceProvider].arch
+        jobOfferArch = job_offer.arch
 
+        # the only case we don't match is here the resource provider is CPU only and the job requires a CPU
+        if resourceProviderArch == Architecture.cpu and jobOfferArch == Architecture.gpu:
+            self.logger.info(f"Architecture mismatch (RP=CPU, JO=GPU)")
+            return(False, False)
 
         # JO.trustedMediators intersection RP.trustedMediators != empty
         for i in self.resource_providers[resource_offer.resourceProvider].trustedMediators:

--- a/src/python/modicum/cli.py
+++ b/src/python/modicum/cli.py
@@ -726,11 +726,11 @@ def runLilypadCLI(template, params, mediator):
     JC = JobCreator.JobCreator(index, False)
     
     # User facing, quiet logging
-    import logging
-    logger = logging.getLogger("JobCreator")
-    logger.setLevel(logging.ERROR)
-    logger = logging.getLogger("EthereumClient")
-    logger.setLevel(logging.ERROR)
+    # import logging
+    # logger = logging.getLogger("JobCreator")
+    # logger.setLevel(logging.ERROR)
+    # logger = logging.getLogger("EthereumClient")
+    # logger.setLevel(logging.ERROR)
 
     print(f"\n🌟 Lilypad submitting job {template}({params}) 🌟\n")
 

--- a/src/python/modules/cowsay.py
+++ b/src/python/modules/cowsay.py
@@ -30,3 +30,5 @@ def _cowsay(params: str):
             "Verifier": "Noop"
         }
     }
+
+_cowsay.requireGPU = False

--- a/src/python/modules/deterministic_wasm.py
+++ b/src/python/modules/deterministic_wasm.py
@@ -44,3 +44,5 @@ def _deterministic_wasm(params: dict):
             ]
         }
     }
+
+_deterministic_wasm.requireGPU = False

--- a/src/python/modules/filecoin_data_prep.py
+++ b/src/python/modules/filecoin_data_prep.py
@@ -66,3 +66,5 @@ def _filecoin_data_prep(params: dict):
             ]
         }
     }
+
+_filecoin_data_prep.requireGPU = False

--- a/src/python/modules/lora.py
+++ b/src/python/modules/lora.py
@@ -1,6 +1,6 @@
 import json
 
-def _sdxl(params: str):
+def _lora(params: str):
     params = json.loads(params)
     if not isinstance(params, dict):
         raise Exception(
@@ -59,3 +59,5 @@ def _sdxl(params: str):
             ]
         }
     }
+
+_lora.requireGPU = True

--- a/src/python/modules/sdxl.py
+++ b/src/python/modules/sdxl.py
@@ -54,3 +54,5 @@ def _sdxl(params: str):
             ]
         }
     }
+
+_sdxl.requireGPU = True

--- a/src/python/modules/stable_diffusion.py
+++ b/src/python/modules/stable_diffusion.py
@@ -47,3 +47,6 @@ def _stable_diffusion(params: str):
             ]
         }
     }
+
+
+_stable_diffusion.requireGPU = True

--- a/stack
+++ b/stack
@@ -90,10 +90,16 @@ function contract-address() {
 
 function compile-contract() {
   source ${DIR}/.env
+  if [[ -z "$QUICK_RESET" ]]; then
+    (
+      set -euo pipefail
+      cd src/js
+      npm install
+    )
+  fi
   (
     set -euo pipefail
     cd src/js
-    npm install
     npx hardhat compile
   )
 }


### PR DESCRIPTION
This will run `nvidia-container-cli` to see how many GPUs we have - if there are > 0 then it will register as arch `gpu` - otherwise register a arch `cpu`

Each module now has a setting called `requireGPU` which ends up configuring the arch of the job offer (to gpu or cpu depending)

Then - the solver will match CPU jobs to GPU nodes but NOT GPU jobs to CPU nodes

This should result in only nodes with GPUs ever running GPU jobs