### PR TITLE
cli: version display fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,5 @@ release:
 
 install-windows:
 	make release
-	cp ./bin/lilypad.exe $env:GOBIN
+	cp ./bin/lilypad.exe $$GOBIN
+#Ps1: cmd	cp ./bin/lilypad.exe $env:GOBIN

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,8 @@ release:
 
 
 
+.PHONY: release install
+
+install-windows:
+	make release
+	cp ./bin/lilypad.exe $env:GOBIN

--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,8 @@ release:
 	go build -v -ldflags="\
 		-X 'github.com/bacalhau-project/lilypad/cmd/lilypad.VERSION=$$(git describe --tags --abbrev=0)' \
 		-X 'github.com/bacalhau-project/lilypad/cmd/lilypad.COMMIT_SHA=$$(git rev-parse HEAD)' \
-	" .
-	./lilypad version
+	" -o bin/
+	./bin/lilypad version
+
+
+

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ release:
 
 .PHONY: release install
 
-install-windows:
+install:
 	make release
 	cp ./bin/lilypad.exe $$GOBIN
 #Ps1: cmd	cp ./bin/lilypad.exe $env:GOBIN

--- a/cmd/lilypad/root.go
+++ b/cmd/lilypad/root.go
@@ -18,7 +18,7 @@ func NewRootCmd() *cobra.Command {
 	RootCmd := &cobra.Command{
 		Use:   getCommandLineExecutable(),
 		Short: "Lilypad",
-		Long:  fmt.Sprintf("Lilypad: %s \n Commit: %s \n", VERSION, COMMIT_SHA),
+		Long:  fmt.Sprintf("Lilypad: %s \nCommit: %s \n", VERSION, COMMIT_SHA),
 	}
 	RootCmd.AddCommand(newSolverCmd())
 	RootCmd.AddCommand(newResourceProviderCmd())

--- a/cmd/lilypad/root.go
+++ b/cmd/lilypad/root.go
@@ -2,6 +2,7 @@ package lilypad
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -17,7 +18,7 @@ func NewRootCmd() *cobra.Command {
 	RootCmd := &cobra.Command{
 		Use:   getCommandLineExecutable(),
 		Short: "Lilypad",
-		Long:  `Lilypad`,
+		Long:  fmt.Sprintf("Lilypad: %s \n Commit: %s \n", VERSION, COMMIT_SHA),
 	}
 	RootCmd.AddCommand(newSolverCmd())
 	RootCmd.AddCommand(newResourceProviderCmd())

--- a/cmd/lilypad/root.go
+++ b/cmd/lilypad/root.go
@@ -10,9 +10,10 @@ import (
 
 var Fatal = FatalErrorHandler
 
-func init() { //nolint:gochecknoinits
-	NewRootCmd()
-}
+//FIXME: why @Kai?
+//func init() { //nolint:gochecknoinits
+//	NewRootCmd()
+//}
 
 func NewRootCmd() *cobra.Command {
 	RootCmd := &cobra.Command{

--- a/cmd/lilypad/run.go
+++ b/cmd/lilypad/run.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -41,7 +42,7 @@ func newRunCmd() *cobra.Command {
 
 func runJob(cmd *cobra.Command, options jobcreator.JobCreatorOptions) error {
 	c := color.New(color.FgCyan).Add(color.Bold)
-	c.Print(`
+	header := `
 ⠀⠀⠀⠀⠀⠀⣀⣤⣤⢠⣤⣀⠀⠀⠀⠀⠀
 ⠀⠀⠀⠀⢴⣿⣿⣿⣿⢸⣿⡟⠀⠀⠀⠀⠀    ██╗     ██╗██╗  ██╗   ██╗██████╗  █████╗ ██████╗ 
 ⠀⠀⣰⣿⣦⡙⢿⣿⣿⢸⡿⠀⠀⠀⠀⢀⠀    ██║     ██║██║  ╚██╗ ██╔╝██╔══██╗██╔══██╗██╔══██╗
@@ -52,7 +53,12 @@ func runJob(cmd *cobra.Command, options jobcreator.JobCreatorOptions) error {
 ⠀⠀⠀⠉⢾⣿⣿⣿⣿⢸⣿⣿⣿⡷⠈⠀⠀                                                  
 ⠀⠀⠀⠀⠀⠈⠙⠛⠛⠘⠛⠋⠁⠀ ⠀⠀⠀   Decentralized Compute Network  https://lilypad.tech
 
-`)
+`
+	if VERSION != "" {
+		header = strings.Replace(header, "v2", VERSION, 1)
+	}
+	c.Print(header)
+
 	spinner, err := createSpinner("Lilypad submitting job", "🌟")
 	if err != nil {
 		fmt.Printf("failed to make spinner from config struct: %v\n", err)

--- a/cmd/lilypad/version.go
+++ b/cmd/lilypad/version.go
@@ -50,3 +50,9 @@ func runVersion(cmd *cobra.Command) error {
 
 	return nil
 }
+
+//func init() {
+//	if VERSION == "" {
+//		VERSION = "v2" //TODO: @release, FIX: L41
+//	}
+//}

--- a/main.go
+++ b/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/bacalhau-project/lilypad/cmd/lilypad"
 )
 
@@ -11,5 +9,5 @@ func main() {
 }
 
 func init() {
-	fmt.Printf("Lilypad: %s\n", lilypad.VERSION)
+	//fmt.Printf("Lilypad: %s\n", lilypad.VERSION)
 }


### PR DESCRIPTION
- [x] Display version in `run` command

![image](https://github.com/bacalhau-project/lilypad/assets/24226219/94352999-1f3e-4cf0-8e23-749d6f2909ef)


- [x] Fix dup version displays due to init commands
- [x] Comment dead code of @binocarlos  
- [x] Add scripts to install in windows 